### PR TITLE
Include NGit installer fragments in NuGet packge

### DIFF
--- a/Install/WiX2/Source Files/Export/ICSharpCode.SharpZipLib.wxs
+++ b/Install/WiX2/Source Files/Export/ICSharpCode.SharpZipLib.wxs
@@ -1,0 +1,13 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
+  <Fragment Id="SharpZip">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="SharpZip" Guid="{B4345D56-1280-4CED-8B60-5845F7DCE42F}" DiskId="1">
+        <File Id="ICSharpCode.SharpZipLib.dll" Name="SharpZip.dll" LongName="ICSharpCode.SharpZipLib.dll" Source="..\Files\ICSharpCode.SharpZipLib.dll" />
+      </Component>
+    </DirectoryRef>
+
+    <FeatureRef Id="Product">
+      <ComponentRef Id="SharpZip"/>
+    </FeatureRef>
+  </Fragment>
+</Wix>

--- a/Install/WiX2/Source Files/Export/RedGate.ThirdParty.Mono.Security.wxs
+++ b/Install/WiX2/Source Files/Export/RedGate.ThirdParty.Mono.Security.wxs
@@ -1,0 +1,13 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
+  <Fragment Id="MonoSec">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="MonoSec" Guid="{9489042B-5008-4AD0-89B7-76D9409288B8}" DiskId="1">
+        <File Id="Mono.Security.dll" Name="MonoSec.dll" LongName="Mono.Security.dll" Source="..\Files\Mono.Security.dll" />
+      </Component>
+    </DirectoryRef>
+
+    <FeatureRef Id="Product">
+      <ComponentRef Id="MonoSec"/>
+    </FeatureRef>
+  </Fragment>
+</Wix>

--- a/Install/WiX2/Source Files/Export/RedGate.ThirdParty.NGit.wxs
+++ b/Install/WiX2/Source Files/Export/RedGate.ThirdParty.NGit.wxs
@@ -1,0 +1,18 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2003/01/wi">
+  <Fragment Id="NGit">
+    <DirectoryRef Id="INSTALLDIR">
+      <Component Id="NGit" Guid="{914081CA-6DA5-439D-B656-87B4DB2982D4}" DiskId="1">
+        <File Id="NGit.dll" Name="NGit.dll" LongName="NGit.dll" Source="..\Files\NGit.dll" />
+        <File Id="NSch.dll" Name="NSch.dll" LongName="NSch.dll" Source="..\Files\NSch.dll" />
+        <File Id="Sharpen.dll" Name="Sharpen.dll" LongName="Sharpen.dll" Source="..\Files\Sharpen.dll" />
+      </Component>
+    </DirectoryRef>
+
+    <FeatureRef Id="Product">
+      <ComponentRef Id="NGit"/>
+    </FeatureRef>
+
+    <FragmentRef Id="MonoSec" />
+    <FragmentRef Id="SharpZip" />
+  </Fragment>
+</Wix>

--- a/Nuspec/NGit.nuspec
+++ b/Nuspec/NGit.nuspec
@@ -24,5 +24,6 @@
 		<file src="bin\Sharpen.dll" target="lib" />
 		<file src="bin\Sharpen.pdb" target="lib" />
 		<file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.NGit.wxs" target="wix2" />
+		<file src="Install\WiX2\Source Files\Export\ICSharpCode.SharpZipLib.wxs" target="wix2" />
 	</files>
 </package>

--- a/Nuspec/NGit.nuspec
+++ b/Nuspec/NGit.nuspec
@@ -23,5 +23,6 @@
 		<file src="bin\NSch.pdb" target="lib" />
 		<file src="bin\Sharpen.dll" target="lib" />
 		<file src="bin\Sharpen.pdb" target="lib" />
+		<file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.NGit.wxs" target="wix2" />
 	</files>
 </package>

--- a/Nuspec/NGit.nuspec
+++ b/Nuspec/NGit.nuspec
@@ -25,5 +25,6 @@
 		<file src="bin\Sharpen.pdb" target="lib" />
 		<file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.NGit.wxs" target="wix2" />
 		<file src="Install\WiX2\Source Files\Export\ICSharpCode.SharpZipLib.wxs" target="wix2" />
+		<file src="Install\WiX2\Source Files\Export\RedGate.ThirdParty.Mono.Security.wxs" target="wix2" />
 	</files>
 </package>


### PR DESCRIPTION
This pushes the installer fragments for NGit up from `RedGate.Helpers.PartialSchemas` into its own NuGet package, which means that SOCO can install NGit.
