### PR TITLE
Take newlines from patch when creating a file

### DIFF
--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -90,10 +90,10 @@ namespace NGit.Api
 			}
 			if (postExists)
 			{
-				b = new RawText(ReadFile(name + "_PostImage", a != null && a.GetLineDelimiter() == "\r\n"));
+			    bool postShouldHaveCrlf = preExists && a.GetLineDelimiter() != null ? a.GetLineDelimiter() != "\n" : m_UseCrlfPatches;
+			    b = new RawText(ReadFile(name + "_PostImage", postShouldHaveCrlf));
 			}
-			return git.Apply().SetPatch(typeof(DiffFormatterReflowTest).GetResourceAsStream(name
-				 + ".patch", m_UseCrlfPatches)).Call();
+		    return git.Apply().SetPatch(typeof (DiffFormatterReflowTest).GetResourceAsStream(name + ".patch", m_UseCrlfPatches)).Call();
 		}
 
 		/// <exception cref="System.Exception"></exception>

--- a/NGit/NGit.Api/ApplyCommand.cs
+++ b/NGit/NGit.Api/ApplyCommand.cs
@@ -53,6 +53,7 @@ using NGit.Diff;
 using NGit.Internal;
 using NGit.Patch;
 using NGit.Util;
+using NGit.Util.IO;
 using Sharpen;
 
 namespace NGit.Api
@@ -65,6 +66,7 @@ namespace NGit.Api
 	public class ApplyCommand : GitCommand<ApplyResult>
 	{
 		private InputStream @in;
+	    private bool patchContainedCrlf;
 
 		/// <summary>Constructs the command if the patch is to be applied to the index.</summary>
 		/// <remarks>Constructs the command if the patch is to be applied to the index.</remarks>
@@ -110,15 +112,8 @@ namespace NGit.Api
 			try
 			{
 				NGit.Patch.Patch p = new NGit.Patch.Patch();
-				try
-				{
-					p.Parse(@in);
-				}
-				finally
-				{
-					@in.Close();
-				}
-				if (!p.GetErrors().IsEmpty())
+                patchContainedCrlf = p.Parse(@in);
+                if (!p.GetErrors().IsEmpty())
 				{
 					throw new PatchFormatException(p.GetErrors());
 				}
@@ -286,8 +281,9 @@ namespace NGit.Api
 			}
 			// don't touch the file
 			StringBuilder sb = new StringBuilder();
-			string eol = rt.Size() == 0 || (rt.Size() == 1 && rt.IsMissingNewlineAtEnd()) ? "\n"
-				 : rt.GetLineDelimiter();
+		    string eol = rt.Size() == 0 || (rt.Size() == 1 && rt.IsMissingNewlineAtEnd())
+		        ? patchContainedCrlf ? "\r\n" : "\n"
+		        : rt.GetLineDelimiter();
 
 		    for (int index = 0; index < newLines.Count; index++)
 		    {

--- a/NGit/NGit.Api/ApplyCommand.cs
+++ b/NGit/NGit.Api/ApplyCommand.cs
@@ -282,7 +282,7 @@ namespace NGit.Api
 			// don't touch the file
 			StringBuilder sb = new StringBuilder();
 		    string eol = rt.Size() == 0 || (rt.Size() == 1 && rt.IsMissingNewlineAtEnd())
-		        ? patchContainedCrlf ? "\r\n" : "\n"
+		        ? GetLineDelimiter(patchContainedCrlf)
 		        : rt.GetLineDelimiter();
 
 		    for (int index = 0; index < newLines.Count; index++)
@@ -300,7 +300,12 @@ namespace NGit.Api
 			fw.Close();
 		}
 
-		private bool IsChanged(IList<string> ol, IList<string> nl)
+	    private string GetLineDelimiter(bool useCrlf)
+	    {
+	        return useCrlf ? "\r\n" : "\n";
+	    }
+
+	    private bool IsChanged(IList<string> ol, IList<string> nl)
 		{
 			if (ol.Count != nl.Count)
 			{

--- a/NGit/NGit.Patch/Patch.cs
+++ b/NGit/NGit.Patch/Patch.cs
@@ -137,13 +137,15 @@ namespace NGit.Patch
 		/// until EOF is reached.
 		/// </param>
 		/// <exception cref="System.IO.IOException">there was an error reading from the input stream.
-		/// 	</exception>
-		public virtual void Parse(InputStream @is)
+		/// </exception>
+	    /// <returns>true iff CLRFs were detected and replaced during parsing</returns>
+	    public virtual bool Parse(InputStream @is)
 		{
 		    using (var lfOnlyStream = new EolCanonicalizingInputStream(@is, false))
 		    {
 		        byte[] buf = ReadFully(lfOnlyStream);
 		        Parse(buf, 0, buf.Length);
+		        return lfOnlyStream.HasReplacedCrlf;
 		    }
 		}
 

--- a/NGit/NGit.Util.IO/EolCanonicalizingInputStream.cs
+++ b/NGit/NGit.Util.IO/EolCanonicalizingInputStream.cs
@@ -69,7 +69,9 @@ namespace NGit.Util.IO
 
 		private bool detectBinary;
 
-		/// <summary>Creates a new InputStream, wrapping the specified stream</summary>
+	    public bool HasReplacedCrlf { get; private set; }
+
+	    /// <summary>Creates a new InputStream, wrapping the specified stream</summary>
 		/// <param name="in">raw input stream</param>
 		/// <param name="detectBinary">whether binaries should be detected</param>
 		/// <since>2.0</since>
@@ -106,24 +108,25 @@ namespace NGit.Util.IO
 					break;
 				}
 				byte b = buf[ptr++];
-				if (isBinary || b != '\r')
-				{
+				if (isBinary || b != '\r') //"{not \r}"
+                {
 					// Logic for binary files ends here
 					bs[off++] = b;
 					continue;
 				}
-				if (ptr == cnt && !FillBuffer())
-				{
+				if (ptr == cnt && !FillBuffer()) //"\r{EOF}"
+                {
 					bs[off++] = (byte)('\r');
 					break;
 				}
-				if (buf[ptr] == '\n')
+				if (buf[ptr] == '\n')// "\r\n"
 				{
 					bs[off++] = (byte)('\n');
 					ptr++;
+				    HasReplacedCrlf = true;
 				}
-				else
-				{
+                else// "\r{something else}"
+                {
 					bs[off++] = (byte)('\r');
 				}
 			}


### PR DESCRIPTION
We're comitting patches to a Git repo, so when a patch creates a file, if the repo was:
- As-is:
  - I haven't tested whether newlines ever get written out correctly in the diff output, but suspect they do. In which case the newlines in the patch would propagate to the created file.
- Change all to CRLF:
  - Everything is the same, so the patch will have the same line endings as other files, so propagating the patch's line endings is the correct thing to do
- Change all to LF: 
  -  As above, but the drifted target is scripted out by us with CRLFs, this could plausibly cause an issue when rebasing LF files on to it.
- Custom where patches are treated differently to sql files (e.g. LFs for patches only): 
  - The file will end up with LFs, the next partial patch to be applied will take this into account.
  - Applying the patch from the open block will flip all line endings to CRLF. Rebasing it would go badly, but luckily we never do that.
  - The drifted target is scripted out by us with CRLFs, this could plausibly cause an issue when rebasing LF files on to it.

I think this will be good enough for now, but if https://github.com/libgit2/libgit2/pull/3223 is not complete by the time it causes issues we might consider adding some manual override and injecting knowledge of which line ending to use higher up.

`DeploymentScriptOptimizationTests` are the ones to watch - they could fail due to a real breakage, or if they were previously passing by luck due to conflicting line endings.
