### PR TITLE
Keep stack trace

### DIFF
--- a/NGit/NGit.Api/FetchCommand.cs
+++ b/NGit/NGit.Api/FetchCommand.cs
@@ -139,10 +139,6 @@ namespace NGit.Api
 				throw new InvalidRemoteException(MessageFormat.Format(JGitText.Get().invalidRemote
 					, remote), e);
 			}
-			catch (NGit.Errors.TransportException e)
-			{
-				throw new NGit.Errors.TransportException(e.Message, e);
-			}
 			catch (URISyntaxException)
 			{
 				throw new InvalidRemoteException(MessageFormat.Format(JGitText.Get().invalidRemote


### PR DESCRIPTION
A user of SOC is hitting TransportException (https://redgatesupport.zendesk.com/agent/tickets/57125), but the useful bit of the stack trace is missing because of this catch & throw new exception. I don't think this serves any purpose, so we should remove it.
