### PR TITLE
Added a special .targets file in the nuget package build/ folder.

### DIFF
--- a/Nuspec/NGit.nuspec
+++ b/Nuspec/NGit.nuspec
@@ -17,6 +17,7 @@
 		</dependencies>
 	</metadata>
 	<files>
+		<file src="Nuspec\RedGate.ThirdParty.NGit.targets" target="build" />
 		<file src="bin\NGit.dll" target="lib" />
 		<file src="bin\NGit.pdb" target="lib" />
 		<file src="NGit.license.txt" target="App_Readme" />

--- a/Nuspec/RedGate.ThirdParty.NGit.targets
+++ b/Nuspec/RedGate.ThirdParty.NGit.targets
@@ -1,0 +1,12 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <!--
+    Add the license files of the nuget package as linked items in the project file.
+    + get them to be copied to the build output folder.
+    -->
+    <None Include="$(MSBuildThisFileDirectory)..\App_Readme\**">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This .targets file is responsible for copying the license files to the build output folder.

This means we won't have to use custom post build events in projects referencing
the RedGate.ThirdParty.NGit package
