### PR TITLE
Fix bug with files/hunks starting with newline

### DIFF
--- a/NGit.Test/NGit.Diff/RawTextTest.cs
+++ b/NGit.Test/NGit.Diff/RawTextTest.cs
@@ -222,6 +222,14 @@ namespace NGit.Diff
 			NUnit.Framework.Assert.IsFalse(rt.IsMissingNewlineAtEnd());
 		}
 
+        [NUnit.Framework.Test]
+	    public virtual void LineDelimiterStartingWithCharacterReturn()
+	    {
+            var rt = new RawText(Constants.EncodeASCII("\nfoo"));
+            NUnit.Framework.Assert.AreEqual("\n", rt.GetLineDelimiter());
+            NUnit.Framework.Assert.IsTrue(rt.IsMissingNewlineAtEnd());
+        }
+
 		private static RawText T(string text)
 		{
 			StringBuilder r = new StringBuilder();

--- a/NGit/NGit.Diff/RawText.cs
+++ b/NGit/NGit.Diff/RawText.cs
@@ -338,7 +338,8 @@ namespace NGit.Diff
 			{
 				return null;
 			}
-			if (content.Length > 1 && content[e - 2] == '\r')
+		    var potentialLinefeedIndex = e - 2;
+		    if (potentialLinefeedIndex >= 0 && content[potentialLinefeedIndex] == '\r')
 			{
 				return "\r\n";
 			}


### PR DESCRIPTION
If a diff started with "\n" and had more than one character this threw and `IndexOutOfRangeException`
i.e. `e=1, content.Length>=2`

Verified in SQL Source Control where this was reproducibly causing a problem with Doug Tucker's repo.
