### PR TITLE
Throw some useful information when throwing a PatchApplyException when modifying a line

### DIFF
--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -45,6 +45,7 @@ using System.IO;
 using System.Text;
 using NGit;
 using NGit.Api;
+using NGit.Api.Errors;
 using NGit.Diff;
 using NUnit.Framework;
 using Sharpen;
@@ -139,13 +140,15 @@ namespace NGit.Api
 			NUnit.Framework.Assert.IsFalse(new FilePath(db.WorkTree, "D").Exists());
 		}
 
-	    /// <exception cref="System.Exception"></exception>
-		public virtual void TestFailureF1()
+        /// <exception cref="System.Exception"></exception>
+        [Test, ExpectedException(typeof(PatchFormatException))]
+        public virtual void TestFailureF1()
 		{
 			Init("F1", true, false);
 		}
 
 	    /// <exception cref="System.Exception"></exception>
+	    [Test, ExpectedException(typeof(PatchApplyException))]
 		public virtual void TestFailureF2()
 		{
 			Init("F2", true, false);

--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -154,8 +154,15 @@ namespace NGit.Api
 			Init("F2", true, false);
 		}
 
-	    /// <exception cref="System.Exception"></exception>
-		[NUnit.Framework.Test]
+        /// <exception cref="System.Exception"></exception>
+        [Test]
+        public virtual void ThePatchApplyExceptionShouldContainDetailsOfTheFailureIfTheChangeTypeWasModify()
+        {
+            Assert.That(() => Init("F2", true, false), Throws.InnerException.TypeOf<PatchApplyModifiedException>());
+        }
+
+        /// <exception cref="System.Exception"></exception>
+        [NUnit.Framework.Test]
 		public virtual void TestModifyE()
 		{
 			ApplyResult result = Init("E");

--- a/NGit/NGit.Api.Errors/PatchApplyModifiedException.cs
+++ b/NGit/NGit.Api.Errors/PatchApplyModifiedException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace NGit.Api.Errors
+{
+    internal class PatchApplyModifiedException : Exception
+    {
+        public string FilePath { get; }
+        public string Hunk { get; }
+        public string HunkLine { get; }
+        public string LineToReplace { get; }
+
+        public PatchApplyModifiedException(string filePath, string hunk, string hunkLine, string lineToReplace)
+        {
+            FilePath = filePath;
+            Hunk = hunk;
+            HunkLine = hunkLine;
+            LineToReplace = lineToReplace;
+        }
+    }
+}

--- a/NGit/NGit.Api/ApplyCommand.cs
+++ b/NGit/NGit.Api/ApplyCommand.cs
@@ -248,7 +248,7 @@ namespace NGit.Api
 								, 1)))
 							{
 								throw new PatchApplyException(MessageFormat.Format(JGitText.Get().patchApplyException
-									, hh));
+									, hh), new PatchApplyModifiedException(f.GetAbsolutePath(), buffer, hunkLine, newLines[hh.GetNewStartLine() - 1 + pos]));
 							}
 							pos++;
 							break;
@@ -261,7 +261,7 @@ namespace NGit.Api
 								, 1)))
 							{
 								throw new PatchApplyException(MessageFormat.Format(JGitText.Get().patchApplyException
-									, hh));
+									, hh), new PatchApplyModifiedException(f.GetAbsolutePath(), buffer, hunkLine, newLines[index]));
 							}
 							newLines.Remove(index);
 							break;

--- a/NGit/NGit.csproj
+++ b/NGit/NGit.csproj
@@ -40,6 +40,7 @@
     <Reference Include="ICSharpCode.SharpZipLib" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NGit.Api.Errors\PatchApplyModifiedException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NGit\AbbreviatedObjectId.cs" />
     <Compile Include="NGit\AnyObjectId.cs" />


### PR DESCRIPTION
This adds an inner exception to `PatchApplyException`.

The intention is that the `BlockDeployment` repository will catch this and log details from the inner exception, to make it easier to support and diagnose causes of SOC-7590.
