### PR TITLE
Make the new exception public

### DIFF
--- a/NGit/NGit.Api.Errors/PatchApplyModifiedException.cs
+++ b/NGit/NGit.Api.Errors/PatchApplyModifiedException.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace NGit.Api.Errors
 {
-    internal class PatchApplyModifiedException : Exception
+    public sealed class PatchApplyModifiedException : Exception
     {
         public string FilePath { get; }
         public string Hunk { get; }


### PR DESCRIPTION
The new exception needs to be public so that we can make use of its data when it is thrown.
