### PR TITLE
Soc 7590 line endings

### DIFF
--- a/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
@@ -1,0 +1,32 @@
+using System.IO;
+using NUnit.Framework;
+
+namespace NGit.Api
+{
+    public class ApplyCommandLineEndingsTests : RepositoryTestCase
+    {
+        [Test]
+        public void ApplyingPatchWithInconsistentMacLineEndingsIsSuccessfullyApplied()
+        {
+            const string pre = "a\r\r\nb";
+            const string post = "a\r\nb";
+            var git = new Git(db);
+            var stream = new MemoryStream();
+            var modifiedFile = Path.Combine(db.WorkTree, "file.txt");
+
+            File.WriteAllText(modifiedFile, pre);
+            git.Add().AddFilepattern(".").Call();
+            git.Commit().SetMessage("Initial commit").Call();
+
+            File.WriteAllText(modifiedFile, post);
+            git.Diff().SetOutputStream(stream).Call();
+
+            stream.Position = 0;
+            File.WriteAllText(modifiedFile, pre);
+
+            git.Apply().SetPatch(stream).Call();
+
+            Assert.That(File.ReadAllText(modifiedFile), Is.EqualTo(post));
+        }
+    }
+}

--- a/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Text;
 using NUnit.Framework;
 
 namespace NGit.Api
@@ -11,22 +12,33 @@ namespace NGit.Api
             const string pre = "a\r\r\nb";
             const string post = "a\r\nb";
             var git = new Git(db);
-            var stream = new MemoryStream();
             var modifiedFile = Path.Combine(db.WorkTree, "file.txt");
 
             File.WriteAllText(modifiedFile, pre);
             git.Add().AddFilepattern(".").Call();
             git.Commit().SetMessage("Initial commit").Call();
 
-            File.WriteAllText(modifiedFile, post);
-            git.Diff().SetOutputStream(stream).Call();
+            var patch = GetPatch(modifiedFile, pre, post, git);
 
-            stream.Position = 0;
-            File.WriteAllText(modifiedFile, pre);
-
-            git.Apply().SetPatch(stream).Call();
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(patch)))
+            {
+                git.Apply().SetPatch(stream).Call();
+            }
 
             Assert.That(File.ReadAllText(modifiedFile), Is.EqualTo(post));
+        }
+
+        private static string GetPatch(string modifiedFile, string originalText, string newText, Git git)
+        {
+            using (var stream = new MemoryStream())
+            {
+                File.WriteAllText(modifiedFile, newText);
+                git.Diff().SetOutputStream(stream).Call();
+                
+                File.WriteAllText(modifiedFile, originalText);
+
+                return Encoding.ASCII.GetString(stream.ToArray());
+            }
         }
     }
 }

--- a/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandLineEndingsTests.cs
@@ -6,6 +6,14 @@ namespace NGit.Api
 {
     public class ApplyCommandLineEndingsTests : RepositoryTestCase
     {
+        // This test covers the case where Patch files where being parsed twice for windows line endings meaning a\r\r\nb would be converted to [a,b]
+        // But the original file would be parsed as [a\r,b], so when being compared during apply it would detect the change and error
+        // We had 3 possible fixes
+        //  1 - Ignore trailing \r in ApplyCommand.cs (This just plasters over the issue of parsing being different)
+        //  2 - Don't remove the \r during read and instead understand line windows line endings in the patch parsing (See https://github.com/red-gate/ngit/pull/17 for the change)
+        //  3 - Convert all Windows Line Endings to Unix whenever we parse input. This is a much larger change, but would mean we can always assume Unix line endings, making parsing of the input easier.
+
+
         [Test]
         public void ApplyingPatchWithInconsistentMacLineEndingsIsSuccessfullyApplied()
         {

--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -204,7 +204,10 @@ namespace NGit.Api
 				()[0]);
 			CheckFile(new FilePath(db.WorkTree, "Z"), b.GetString(0, b.Size(), false));
 		}
+	}
 
+    public class ApplyCommandLineEndingsTests : RepositoryTestCase
+    {
         [Test]
         public void ApplyingPatchWithInconsistentMacLineEndingsIsSuccessfullyApplied()
         {
@@ -228,5 +231,6 @@ namespace NGit.Api
 
             Assert.That(File.ReadAllText(modifiedFile), Is.EqualTo(post));
         }
-	}
+    }
+
 }

--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -205,32 +205,4 @@ namespace NGit.Api
 			CheckFile(new FilePath(db.WorkTree, "Z"), b.GetString(0, b.Size(), false));
 		}
 	}
-
-    public class ApplyCommandLineEndingsTests : RepositoryTestCase
-    {
-        [Test]
-        public void ApplyingPatchWithInconsistentMacLineEndingsIsSuccessfullyApplied()
-        {
-            const string pre = "a\r\r\nb";
-            const string post = "a\r\nb";
-            var git = new Git(db);
-            var stream = new MemoryStream();
-            var modifiedFile = Path.Combine(db.WorkTree, "file.txt");
-
-            File.WriteAllText(modifiedFile, pre);
-            git.Add().AddFilepattern(".").Call();
-            git.Commit().SetMessage("Initial commit").Call();
-
-            File.WriteAllText(modifiedFile, post);
-            git.Diff().SetOutputStream(stream).Call();
-
-            stream.Position = 0;
-            File.WriteAllText(modifiedFile, pre);
-
-            git.Apply().SetPatch(stream).Call();
-
-            Assert.That(File.ReadAllText(modifiedFile), Is.EqualTo(post));
-        }
-    }
-
 }

--- a/NGit.Test/NGit.Api/ApplyCommandTest.cs
+++ b/NGit.Test/NGit.Api/ApplyCommandTest.cs
@@ -204,5 +204,29 @@ namespace NGit.Api
 				()[0]);
 			CheckFile(new FilePath(db.WorkTree, "Z"), b.GetString(0, b.Size(), false));
 		}
+
+        [Test]
+        public void ApplyingPatchWithInconsistentMacLineEndingsIsSuccessfullyApplied()
+        {
+            const string pre = "a\r\r\nb";
+            const string post = "a\r\nb";
+            var git = new Git(db);
+            var stream = new MemoryStream();
+            var modifiedFile = Path.Combine(db.WorkTree, "file.txt");
+
+            File.WriteAllText(modifiedFile, pre);
+            git.Add().AddFilepattern(".").Call();
+            git.Commit().SetMessage("Initial commit").Call();
+
+            File.WriteAllText(modifiedFile, post);
+            git.Diff().SetOutputStream(stream).Call();
+
+            stream.Position = 0;
+            File.WriteAllText(modifiedFile, pre);
+
+            git.Apply().SetPatch(stream).Call();
+
+            Assert.That(File.ReadAllText(modifiedFile), Is.EqualTo(post));
+        }
 	}
 }

--- a/NGit.Test/NGit.Patch/PatchTest.cs
+++ b/NGit.Test/NGit.Patch/PatchTest.cs
@@ -87,8 +87,8 @@ namespace NGit.Patch
 				, fRepositoryConfigTest.GetNewPath());
 			NUnit.Framework.Assert.AreEqual("org.eclipse.jgit/src/org/spearce/jgit/lib/RepositoryConfig.java"
 				, fRepositoryConfig.GetNewPath());
-			NUnit.Framework.Assert.AreEqual(572, fRepositoryConfigTest.startOffset);
-			NUnit.Framework.Assert.AreEqual(1490, fRepositoryConfig.startOffset);
+			NUnit.Framework.Assert.AreEqual(m_Crlf ? 586 : 572, fRepositoryConfigTest.startOffset);
+			NUnit.Framework.Assert.AreEqual(m_Crlf ? 1520 : 1490, fRepositoryConfig.startOffset);
 			NUnit.Framework.Assert.AreEqual("da7e704", fRepositoryConfigTest.GetOldId().Name);
 			NUnit.Framework.Assert.AreEqual("34ce04a", fRepositoryConfigTest.GetNewId().Name);
 			NUnit.Framework.Assert.AreEqual(FileHeader.PatchType.UNIFIED, fRepositoryConfigTest
@@ -101,7 +101,7 @@ namespace NGit.Patch
 			{
 				HunkHeader h = fRepositoryConfigTest.GetHunks()[0];
 				NUnit.Framework.Assert.AreSame(fRepositoryConfigTest, h.GetFileHeader());
-				NUnit.Framework.Assert.AreEqual(921, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 939 : 921, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(109, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(4, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(109, h.GetNewStartLine());
@@ -111,7 +111,7 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(0, h.GetOldImage().GetLinesDeleted());
 				NUnit.Framework.Assert.AreSame(fRepositoryConfigTest.GetOldId(), h.GetOldImage().
 					GetId());
-				NUnit.Framework.Assert.AreEqual(1490, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 1520 : 1490, h.endOffset);
 			}
 			NUnit.Framework.Assert.AreEqual("45c2f8a", fRepositoryConfig.GetOldId().Name);
 			NUnit.Framework.Assert.AreEqual("3291bba", fRepositoryConfig.GetNewId().Name);
@@ -125,7 +125,7 @@ namespace NGit.Patch
 			{
 				HunkHeader h = fRepositoryConfig.GetHunks()[0];
 				NUnit.Framework.Assert.AreSame(fRepositoryConfig, h.GetFileHeader());
-				NUnit.Framework.Assert.AreEqual(1803, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 1837 : 1803, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(236, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(9, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(236, h.GetNewStartLine());
@@ -135,11 +135,11 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(2, h.GetOldImage().GetLinesDeleted());
 				NUnit.Framework.Assert.AreSame(fRepositoryConfig.GetOldId(), h.GetOldImage().GetId
 					());
-				NUnit.Framework.Assert.AreEqual(2434, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 2480 : 2434, h.endOffset);
 			}
 			{
 				HunkHeader h = fRepositoryConfig.GetHunks()[1];
-				NUnit.Framework.Assert.AreEqual(2434, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 2480 : 2434, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(300, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(7, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(300, h.GetNewStartLine());
@@ -147,11 +147,11 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(6, h.GetLinesContext());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesAdded());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesDeleted());
-				NUnit.Framework.Assert.AreEqual(2816, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 2871 : 2816, h.endOffset);
 			}
 			{
 				HunkHeader h = fRepositoryConfig.GetHunks()[2];
-				NUnit.Framework.Assert.AreEqual(2816, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 2871 : 2816, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(954, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(7, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(954, h.GetNewStartLine());
@@ -159,7 +159,7 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(6, h.GetLinesContext());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesAdded());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesDeleted());
-				NUnit.Framework.Assert.AreEqual(3035, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 3099 : 3035, h.endOffset);
 			}
 		}
 
@@ -283,7 +283,7 @@ namespace NGit.Patch
 			NUnit.Framework.Assert.AreSame(fh, rev.GetFileHeader());
 			NUnit.Framework.Assert.AreEqual(BinaryHunk.Type.DELTA_DEFLATED, fwd.GetType());
 			NUnit.Framework.Assert.AreEqual(BinaryHunk.Type.DELTA_DEFLATED, rev.GetType());
-			NUnit.Framework.Assert.AreEqual(496, fh.endOffset);
+			NUnit.Framework.Assert.AreEqual(m_Crlf ? 514 : 496, fh.endOffset);
 		}
 
 		/// <exception cref="System.IO.IOException"></exception>
@@ -295,7 +295,7 @@ namespace NGit.Patch
 			NUnit.Framework.Assert.IsTrue(p.GetErrors().IsEmpty());
 			FileHeader f = p.GetFiles()[0];
 			NUnit.Framework.Assert.AreEqual("a", f.GetNewPath());
-			NUnit.Framework.Assert.AreEqual(252, f.startOffset);
+			NUnit.Framework.Assert.AreEqual(m_Crlf ? 261 : 252, f.startOffset);
 			NUnit.Framework.Assert.AreEqual("2e65efe", f.GetOldId().Name);
 			NUnit.Framework.Assert.AreEqual("f2ad6c7", f.GetNewId().Name);
 			NUnit.Framework.Assert.AreEqual(FileHeader.PatchType.UNIFIED, f.GetPatchType());
@@ -305,7 +305,7 @@ namespace NGit.Patch
 			{
 				HunkHeader h = f.GetHunks()[0];
 				NUnit.Framework.Assert.AreSame(f, h.GetFileHeader());
-				NUnit.Framework.Assert.AreEqual(317, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 330 : 317, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(1, h.GetNewStartLine());
@@ -314,7 +314,7 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesAdded());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesDeleted());
 				NUnit.Framework.Assert.AreSame(f.GetOldId(), h.GetOldImage().GetId());
-				NUnit.Framework.Assert.AreEqual(363, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 380 : 363, h.endOffset);
 			}
 		}
 
@@ -327,7 +327,7 @@ namespace NGit.Patch
 			NUnit.Framework.Assert.IsTrue(p.GetErrors().IsEmpty());
 			FileHeader f = p.GetFiles()[0];
 			NUnit.Framework.Assert.AreEqual("a", f.GetNewPath());
-			NUnit.Framework.Assert.AreEqual(256, f.startOffset);
+			NUnit.Framework.Assert.AreEqual(m_Crlf ? 265 : 256, f.startOffset);
 			NUnit.Framework.Assert.AreEqual("f2ad6c7", f.GetOldId().Name);
 			NUnit.Framework.Assert.AreEqual("c59d9b6", f.GetNewId().Name);
 			NUnit.Framework.Assert.AreEqual(FileHeader.PatchType.UNIFIED, f.GetPatchType());
@@ -337,7 +337,7 @@ namespace NGit.Patch
 			{
 				HunkHeader h = f.GetHunks()[0];
 				NUnit.Framework.Assert.AreSame(f, h.GetFileHeader());
-				NUnit.Framework.Assert.AreEqual(321, h.startOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 334 : 321, h.startOffset);
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetStartLine());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLineCount());
 				NUnit.Framework.Assert.AreEqual(1, h.GetNewStartLine());
@@ -346,7 +346,7 @@ namespace NGit.Patch
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesAdded());
 				NUnit.Framework.Assert.AreEqual(1, h.GetOldImage().GetLinesDeleted());
 				NUnit.Framework.Assert.AreSame(f.GetOldId(), h.GetOldImage().GetId());
-				NUnit.Framework.Assert.AreEqual(367, h.endOffset);
+				NUnit.Framework.Assert.AreEqual(m_Crlf ? 384 : 367, h.endOffset);
 			}
 		}
 

--- a/NGit.Test/NGit.Patch/PatchTest.cs
+++ b/NGit.Test/NGit.Patch/PatchTest.cs
@@ -80,7 +80,7 @@ namespace NGit.Patch
 		{
 			NGit.Patch.Patch p = ParseTestPatchFile();
 			NUnit.Framework.Assert.AreEqual(2, p.GetFiles().Count);
-			NUnit.Framework.Assert.IsTrue(p.GetErrors().IsEmpty());
+			NUnit.Framework.Assert.That(p.GetErrors(), Is.Empty);
 			FileHeader fRepositoryConfigTest = p.GetFiles()[0];
 			FileHeader fRepositoryConfig = p.GetFiles()[1];
 			NUnit.Framework.Assert.AreEqual("org.eclipse.jgit.test/tst/org/spearce/jgit/lib/RepositoryConfigTest.java"

--- a/NGit.Test/NGit.Test.csproj
+++ b/NGit.Test/NGit.Test.csproj
@@ -42,6 +42,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NGit.Api\ApplyCommandLineEndingsTests.cs" />
     <Compile Include="NGit.Api\CrlfIndependentApplyCommandTests.cs" />
     <Compile Include="NGit.Api\PatchApplicationTester.cs" />
     <Compile Include="NGit.Util.IO\TypeExtensions.cs" />

--- a/NGit/NGit.Api/ApplyCommand.cs
+++ b/NGit/NGit.Api/ApplyCommand.cs
@@ -66,7 +66,6 @@ namespace NGit.Api
 	public class ApplyCommand : GitCommand<ApplyResult>
 	{
 		private InputStream @in;
-	    private bool patchContainedCrlf;
 
 		/// <summary>Constructs the command if the patch is to be applied to the index.</summary>
 		/// <remarks>Constructs the command if the patch is to be applied to the index.</remarks>
@@ -112,7 +111,7 @@ namespace NGit.Api
 			try
 			{
 				NGit.Patch.Patch p = new NGit.Patch.Patch();
-                patchContainedCrlf = p.Parse(@in);
+                p.Parse(@in);
                 if (!p.GetErrors().IsEmpty())
 				{
 					throw new PatchFormatException(p.GetErrors());
@@ -227,9 +226,11 @@ namespace NGit.Api
 			}
 			IList<string> newLines = new AList<string>(oldLines);
 		    RawText hrt = null;
+		    var containedCRLF = false;
             foreach (HunkHeader hh in fh.GetHunks())
 			{
 				var buffer = Sharpen.Runtime.GetStringForBytes(hh.GetBuffer(), hh.GetStartOffset(), hh.GetEndOffset() - hh.GetStartOffset());
+			    containedCRLF |= buffer.Contains("\r\n");
 				hrt = new RawText(Sharpen.Runtime.GetBytesForString(buffer));
 				IList<string> hunkLines = new AList<string>(hrt.Size());
 				for (int i_1 = 0; i_1 < hrt.Size(); i_1++)
@@ -292,7 +293,7 @@ namespace NGit.Api
 			// don't touch the file
 			StringBuilder sb = new StringBuilder();
 		    string eol = rt.Size() == 0 || (rt.Size() == 1 && rt.IsMissingNewlineAtEnd())
-		        ? GetLineDelimiter(patchContainedCrlf)
+		        ? (containedCRLF ? "\r\n" : "\n")
 		        : rt.GetLineDelimiter();
 
 		    for (int index = 0; index < newLines.Count; index++)
@@ -309,11 +310,6 @@ namespace NGit.Api
 			fw.Write(sb.ToString());
 			fw.Close();
 		}
-
-	    private string GetLineDelimiter(bool useCrlf)
-	    {
-	        return useCrlf ? "\r\n" : "\n";
-	    }
 
 	    private bool IsChanged(IList<string> ol, IList<string> nl)
 		{

--- a/NGit/NGit.Api/ApplyCommand.cs
+++ b/NGit/NGit.Api/ApplyCommand.cs
@@ -230,8 +230,13 @@ namespace NGit.Api
             foreach (HunkHeader hh in fh.GetHunks())
 			{
 				var buffer = Sharpen.Runtime.GetStringForBytes(hh.GetBuffer(), hh.GetStartOffset(), hh.GetEndOffset() - hh.GetStartOffset());
-			    containedCRLF |= buffer.Contains("\r\n");
-				hrt = new RawText(Sharpen.Runtime.GetBytesForString(buffer));
+
+                if (!containedCRLF)
+			    {
+                    containedCRLF |= buffer.Contains("\r\n");
+                }
+
+                hrt = new RawText(Sharpen.Runtime.GetBytesForString(buffer));
 				IList<string> hunkLines = new AList<string>(hrt.Size());
 				for (int i_1 = 0; i_1 < hrt.Size(); i_1++)
 				{

--- a/NGit/NGit.Patch/BinaryHunk.cs
+++ b/NGit/NGit.Patch/BinaryHunk.cs
@@ -168,7 +168,7 @@ namespace NGit.Patch
 			//
 			while (ptr < end)
 			{
-				bool empty = (buf[ptr] == '\n') || (buf[ptr] == '\r' && buf[ptr-1] == '\n');
+				bool empty = (buf[ptr] == '\n') || (buf[ptr] == '\r' && ptr + 1 < end && buf[ptr+1] == '\n');
 				ptr = RawParseUtils.NextLF(buf, ptr);
 				if (empty)
 				{

--- a/NGit/NGit.Patch/BinaryHunk.cs
+++ b/NGit/NGit.Patch/BinaryHunk.cs
@@ -168,7 +168,7 @@ namespace NGit.Patch
 			//
 			while (ptr < end)
 			{
-				bool empty = buf[ptr] == '\n';
+				bool empty = (buf[ptr] == '\n') || (buf[ptr] == '\r' && buf[ptr-1] == '\n');
 				ptr = RawParseUtils.NextLF(buf, ptr);
 				if (empty)
 				{

--- a/NGit/NGit.Patch/FileHeader.cs
+++ b/NGit/NGit.Patch/FileHeader.cs
@@ -445,7 +445,7 @@ namespace NGit.Patch
 				// If buffer[aStart..sp - 1] = buffer[bStart..eol - 1]
 				// we have a valid split.
 				//
-				if (Eq(aStart, sp - 1, bStart, buf[eol-2] == '\r' ? eol - 2 : eol - 1))
+				if (Eq(aStart, sp - 1, bStart, IsWindowsLineEnding(eol)? eol - 2 : eol - 1))
 				{
 					if (buf[bol] == '"')
 					{
@@ -715,7 +715,7 @@ namespace NGit.Patch
 		internal virtual FileMode ParseFileMode(int ptr, int end)
 		{
 			int tmp = 0;
-		    if (buf[end - 2] == '\r') // Ignore windows line ending
+		    if (IsWindowsLineEnding(end)) // Ignore windows line ending
 		    {
 		        end--;
             }
@@ -727,15 +727,22 @@ namespace NGit.Patch
 			return FileMode.FromBits(tmp);
 		}
 
-		internal virtual void ParseIndexLine(int ptr, int end)
+	    private bool IsWindowsLineEnding(int end)
+	    {
+            // end points to the poisition after the \n,
+            // We want to know if the previous character to the \n was \r
+	        return end - 2 > 0 && buf[end - 2] == '\r';
+	    }
+
+	    internal virtual void ParseIndexLine(int ptr, int end)
 		{
 			// "index $asha1..$bsha1[ $mode]" where $asha1 and $bsha1
 			// can be unique abbreviations
 			//
 			int dot2 = RawParseUtils.NextLF(buf, ptr, '.');
 			int mode = RawParseUtils.NextLF(buf, dot2, ' ');
-			oldId = AbbreviatedObjectId.FromString(buf, ptr, buf[dot2 - 2] == '\r' ? dot2 - 2 : dot2 - 1);
-			newId = AbbreviatedObjectId.FromString(buf, dot2 + 1, buf[mode - 2] == '\r' ? mode - 2 : mode - 1);
+			oldId = AbbreviatedObjectId.FromString(buf, ptr, IsWindowsLineEnding(dot2) ? dot2 - 2 : dot2 - 1);
+			newId = AbbreviatedObjectId.FromString(buf, dot2 + 1, IsWindowsLineEnding(mode) ? mode - 2 : mode - 1);
 			if (mode < end)
 			{
 				newMode = oldMode = ParseFileMode(mode, end);

--- a/NGit/NGit.Patch/FileHeader.cs
+++ b/NGit/NGit.Patch/FileHeader.cs
@@ -445,7 +445,7 @@ namespace NGit.Patch
 				// If buffer[aStart..sp - 1] = buffer[bStart..eol - 1]
 				// we have a valid split.
 				//
-				if (Eq(aStart, sp - 1, bStart, eol - 1))
+				if (Eq(aStart, sp - 1, bStart, buf[eol-2] == '\r' ? eol - 2 : eol - 1))
 				{
 					if (buf[bol] == '"')
 					{
@@ -699,6 +699,10 @@ namespace NGit.Patch
 			{
 				r = DEV_NULL;
 			}
+		    if (r.EndsWith("\r")) // If there was a windows line ending then remove it
+		    {
+		        r = r.Substring(0, r.Length - 1);
+		    }
 			return r;
 		}
 
@@ -711,6 +715,10 @@ namespace NGit.Patch
 		internal virtual FileMode ParseFileMode(int ptr, int end)
 		{
 			int tmp = 0;
+		    if (buf[end - 2] == '\r') // Ignore windows line ending
+		    {
+		        end--;
+            }
 			while (ptr < end - 1)
 			{
 				tmp <<= 3;
@@ -726,8 +734,8 @@ namespace NGit.Patch
 			//
 			int dot2 = RawParseUtils.NextLF(buf, ptr, '.');
 			int mode = RawParseUtils.NextLF(buf, dot2, ' ');
-			oldId = AbbreviatedObjectId.FromString(buf, ptr, dot2 - 1);
-			newId = AbbreviatedObjectId.FromString(buf, dot2 + 1, mode - 1);
+			oldId = AbbreviatedObjectId.FromString(buf, ptr, buf[dot2 - 2] == '\r' ? dot2 - 2 : dot2 - 1);
+			newId = AbbreviatedObjectId.FromString(buf, dot2 + 1, buf[mode - 2] == '\r' ? mode - 2 : mode - 1);
 			if (mode < end)
 			{
 				newMode = oldMode = ParseFileMode(mode, end);

--- a/NGit/NGit.Patch/HunkHeader.cs
+++ b/NGit/NGit.Patch/HunkHeader.cs
@@ -380,8 +380,8 @@ SCAN_continue: ;
 			}
 SCAN_break: ;
 			if (last < end && nContext + old.nDeleted - 1 == old.lineCount && nContext + old.
-				nAdded == newLineCount && RawParseUtils.Match(buf, last, NGit.Patch.Patch.SIG_FOOTER
-				) >= 0)
+				nAdded == newLineCount && (RawParseUtils.Match(buf, last, Patch.SIG_FOOTER
+				    ) >= 0 || RawParseUtils.Match(buf, last, Patch.SIG_FOOTER_WINDOWS) >= 0))
 			{
 				// This is an extremely common occurrence of "corruption".
 				// Users add footers with their signatures after this mark,

--- a/NGit/NGit.Patch/Patch.cs
+++ b/NGit/NGit.Patch/Patch.cs
@@ -71,7 +71,7 @@ namespace NGit.Patch
 		private static readonly byte[] BIN_TRAILER = Constants.EncodeASCII(" differ\n");
 		private static readonly byte[] BIN_TRAILER_WINDOWS = Constants.EncodeASCII(" differ\r\n");
 
-	    private static readonly byte[] GIT_BINARY = Constants.EncodeASCII("GIT binary patch\n");
+		private static readonly byte[] GIT_BINARY = Constants.EncodeASCII("GIT binary patch\n");
 		private static readonly byte[] GIT_BINARY_WINDOWS = Constants.EncodeASCII("GIT binary patch\r\n");
 
 		internal static readonly byte[] SIG_FOOTER = Constants.EncodeASCII("-- \n");

--- a/NGit/NGit.Util.IO/EolCanonicalizingInputStream.cs
+++ b/NGit/NGit.Util.IO/EolCanonicalizingInputStream.cs
@@ -69,8 +69,6 @@ namespace NGit.Util.IO
 
 		private bool detectBinary;
 
-	    public bool HasReplacedCrlf { get; private set; }
-
 	    /// <summary>Creates a new InputStream, wrapping the specified stream</summary>
 		/// <param name="in">raw input stream</param>
 		/// <param name="detectBinary">whether binaries should be detected</param>
@@ -123,7 +121,6 @@ namespace NGit.Util.IO
 				{
 					bs[off++] = (byte)('\n');
 					ptr++;
-				    HasReplacedCrlf = true;
 				}
                 else// "\r{something else}"
                 {


### PR DESCRIPTION
Handle line endings in a way such that if given `\r\r\n` it is consistently parsed so a hunk header exception is not thrown.

We do this by not canonicolising line endings in the patch and handling \r\n in the parsing of individual components.

We have a bunch of tests already around line endings but this issue wasn't being caught as it is abount diff producing 1 patch and it being parsed as a slightly different patch. We fix this by reverting a change in #6 and instead we do manual checks in each parse rather than assuming we have read with pure unix line endings.
