### PR TITLE
Adds parameterless constructor

### DIFF
--- a/NGit/NGit.Api.Errors/GitAPIException.cs
+++ b/NGit/NGit.Api.Errors/GitAPIException.cs
@@ -62,5 +62,9 @@ namespace NGit.Api.Errors
 		public GitAPIException(string message) : base(message)
 		{
 		}
+
+	    public GitAPIException()
+	    {
+	    }
 	}
 }

--- a/NGit/NGit.Api.Errors/PatchApplyException.cs
+++ b/NGit/NGit.Api.Errors/PatchApplyException.cs
@@ -65,5 +65,9 @@ namespace NGit.Api.Errors
 		public PatchApplyException(string message) : base(message)
 		{
 		}
-	}
+
+		public PatchApplyException()
+        {
+        }
+    }
 }


### PR DESCRIPTION
To use `PatchApplyException` as a TException in Mock it needs to have a parameterless constructor. 

We need to use this in SoC to fix the test introduced in https://github.com/red-gate/SQLSourceControl/commit/512951f473c07db556c1658c0f5a11f75a5853e8 which previously looked for any `Exception` but was changed to specifically catch `PatchApplyException`.
