### PR TITLE
Remove piece of code that might be causing SOC-8087 bug

### DIFF
--- a/NGit/NGit.Util/FS_Win32.cs
+++ b/NGit/NGit.Util/FS_Win32.cs
@@ -97,22 +97,6 @@ namespace NGit.Util
 			{
 				return gitExe.GetParentFile().GetParentFile();
 			}
-			// This isn't likely to work, if bash is in $PATH, git should
-			// also be in $PATH. But its worth trying.
-			//
-			string w = ReadPipe(UserHome(), new string[] { "bash", "--login", "-c", "which git"
-				 }, Encoding.Default.Name());
-			//
-			//
-			if (w != null)
-			{
-				// The path may be in cygwin/msys notation so resolve it right away
-				gitExe = Resolve(null, w);
-				if (gitExe != null)
-				{
-					return gitExe.GetParentFile().GetParentFile();
-				}
-			}
 			return null;
 		}
 


### PR DESCRIPTION
Fixes [SOC-8087](https://jira.red-gate.com/browse/SOC-8087), SOC-8233, SOC-8234, SOC-8241 and most probably [SC-8826](https://jira.red-gate.com/browse/SC-8826) and [SC-8827](https://jira.red-gate.com/browse/SC-8827).

The code tries to run `bash` on Windows, which either fails if it is not in `PATH` or produces random output of whatever `bash` named program user has on a machine (for example with OpenSSH installation).

As suggested by the original comment in lines 100-101, it does not work indeed.

Relevant TeamCity builds:
1. [NGit #3.0.21](http://buildserver.red-gate.com/viewLog.html?buildId=7712214&tab=buildResultsDiv&buildTypeId=SignedNuGetPackages_NGitNet35)
2. [BlockDeployment #6.0.70](http://buildserver.red-gate.com/project.html?projectId=Opportunities_DatabaseDelivery_OccasionalMigrations&branch_Opportunities_DatabaseDelivery_OccasionalMigrations=fix-soc-8087)
3. [SOC #5.3.4.3483](http://buildserver.red-gate.com/project.html?projectId=SqlSourceControl&tab=projectOverview&branch_SqlSourceControl=fix-soc-8087) - that's where the SA report is thrown from